### PR TITLE
Fix rotate option

### DIFF
--- a/src/captcha.class.php
+++ b/src/captcha.class.php
@@ -482,6 +482,7 @@ class IconCaptcha
             if ($rotateEnabled) {
                 $degree = mt_rand(1, 4);
                 if ($degree !== 4) { // Only if the 'degree' is not the same as what it would already be at.
+                    imagepalettetotruecolor($icon);
                     $icon = imagerotate($icon, $degree * 90, 0);
                 }
             }


### PR DESCRIPTION
Hi, I've been facing issues whenever the rotate option is enabled (image wouldn't load and I would get a NS_ERROR_NET_RESET error in the Network details), after checking the issues list apparently I'm not the only one.

After multiple tests, it seems it only occurs when 180 is passed as the angle to the imagerotate() function. The issue I think is that this function returns a true color image, while the original $icon you're passing isn't.  I'm not sure why it only affects the 180 angle - maybe some black magic is at work with dimensions modification through the function - but I managed to fix the issue with a call to the imagepalettetotruecolor() function to first convert the image to a true color image before rotating it. 

No more errors with any configuration!